### PR TITLE
Update CustomLocalStorageConfig.cs

### DIFF
--- a/SecureLocalStorage/CustomLocalStorageConfig.cs
+++ b/SecureLocalStorage/CustomLocalStorageConfig.cs
@@ -9,7 +9,7 @@ namespace SecureLocalStorage
         public CustomLocalStorageConfig(string defaultPath, string applicationName)
         {
             DefaultPath = defaultPath ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            ApplicationName = ApplicationName;
+            ApplicationName = applicationName;
             StoragePath = Path.Combine(DefaultPath, applicationName);
         }
 


### PR DESCRIPTION
Fix assignment of ApplicationName in CustomLocalStorageConfig

This commit resolves a bug in the constructor of `CustomLocalStorageConfig` where the `ApplicationName` was incorrectly defined. Previously, the `ApplicationName` was set to itself instead of the variable `applicationName`